### PR TITLE
feat: Add Google Analytics integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,6 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+# Environment variables
+.env*
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -737,6 +737,27 @@
         "fontkit": "^2.0.2"
       }
     },
+    "node_modules/@digi4care/astro-google-analytics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@digi4care/astro-google-analytics/-/astro-google-analytics-1.1.1.tgz",
+      "integrity": "sha512-mraf9I+yTbRDfzavZyHy1q7pssjr69hf4Dutg8BNgHcFbkELt2xkVkM723TJJztYM/jICmGu4I1Tjxb32p8jZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@digi4care/astro-google-tagmanager": "^1.0.0"
+      },
+      "peerDependencies": {
+        "astro": "^1.2.1 || ^2.0.0 || ^3.0.0-beta.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/@digi4care/astro-google-tagmanager": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@digi4care/astro-google-tagmanager/-/astro-google-tagmanager-1.6.0.tgz",
+      "integrity": "sha512-xBEYnswcLPNDu62zRGh8W8hbRW97nK02O+SyellcopT4/NMkevygrvxv49xl0ZQeBd6dfJpwbktlBYDJDaRvWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "astro": "^1.2.1 || ^2.0.0 || ^3.0.0-beta.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
@@ -12851,6 +12872,7 @@
       "dependencies": {
         "@app/ui": "0.0.1",
         "@astrojs/preact": "^4.1.0",
+        "@digi4care/astro-google-analytics": "1.1.1",
         "@faker-js/faker": "^10.0.0",
         "@twind/core": "^1.1.3",
         "@twind/preset-autoprefix": "^1.0.7",

--- a/services/web/package.json
+++ b/services/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@app/ui": "0.0.1",
     "@astrojs/preact": "^4.1.0",
+    "@digi4care/astro-google-analytics": "1.1.1",
     "@faker-js/faker": "^10.0.0",
     "@twind/core": "^1.1.3",
     "@twind/preset-autoprefix": "^1.0.7",

--- a/services/web/src/layouts/MainLayout.astro
+++ b/services/web/src/layouts/MainLayout.astro
@@ -1,12 +1,17 @@
 ---
 import Header from "@app/ui/src/Header";
 import TwindSetup from "../components/TwindSetup.astro";
+import {
+  GoogleAnalytics,
+  GoogleAnalyticsNoscript,
+} from "@digi4care/astro-google-analytics";
 
 interface Props {
   title: string;
 }
 
 const { title } = Astro.props;
+const gaId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
 ---
 
 <!doctype html>
@@ -19,8 +24,10 @@ const { title } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <TwindSetup />
+    {gaId && <GoogleAnalytics id={gaId} />}
   </head>
   <body class="bg-gray-100">
+    {gaId && <GoogleAnalyticsNoscript id={gaId} />}
     <Header active="Home" />
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="grid grid-cols-1 lg:grid-cols-12 lg:gap-8">


### PR DESCRIPTION
This commit integrates Google Analytics into the web project.

It uses the `@digi4care/astro-google-analytics` package to add the GA tracking script. The Google Analytics ID is managed via a `PUBLIC_GA_MEASUREMENT_ID` environment variable, which is loaded from a `.env` file at build time.

The main layout has been updated to include the necessary components, and the `.gitignore` file has been updated to exclude `.env` files.