### PR TITLE
test(crawler): run Node tests directly with --experimental-strip-type…

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -37,6 +37,7 @@
     "turbosnap",
     "twind",
     "twind",
+    "renpoto",
     "vgmo",
     "webdev",
     "webperf",

--- a/services/crawler/package.json
+++ b/services/crawler/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "rm -rf lib && tsc",
-    "pretest": "npm run build",
-    "test": "node --test lib/**/*.test.js",
+    "test": "node --test --experimental-strip-types tests/**/*.test.ts",
     "coverage": "c8 npm test && c8 report --reporter=lcov"
   },
   "author": "9renpoto"

--- a/services/crawler/tests/crawler.test.ts
+++ b/services/crawler/tests/crawler.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { fetchFeed } from "../src/main.js";
+import { fetchFeed } from "../src/main.ts";
 
 test("fetchFeed fetches and parses the RSS feed", async () => {
   const items = await fetchFeed("https://www.2083.jp/rss.xml");


### PR DESCRIPTION
…s (no precompile). Update imports to .ts.\nchore(spell): add 'renpoto' to cspell dictionary