### PR TITLE
docs: standardize README, add CONTRIBUTING, and update AGENTS

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing Guide
+
+Thank you for contributing! This repository is a monorepo managed with npm workspaces. For day-to-day structure, commands, and coding conventions, see AGENTS.md.
+
+- Project structure, workspace usage, commands, and style: see `AGENTS.md`.
+- Security reporting and policies: see `SECURITY.md`.
+
+## Prerequisites
+- Node.js 20+ (Node 22+ required to run crawler tests with `--experimental-strip-types`)
+- npm and Git installed
+- Optional: Docker (enables the `secretlint` pre-commit hook)
+
+## Setup
+```sh
+npm ci
+pre-commit install
+```
+
+## Branching, Commits, and PRs
+- Use feature branches (e.g., `feat/ui-button`, `fix/web-login`).
+- Follow Conventional Commits, e.g.:
+  - `feat(ui): add Button`
+  - `fix(crawler): handle empty feed`
+- Keep PRs small and focused; include tests and screenshots for UI changes.
+
+## Common Tasks (Workspaces)
+- Build all: `npm run build --workspaces`
+- Test all: `npm test --workspaces`
+- Run one workspace: `npm run -w <name> <script>` (e.g., `npm run -w @vgmo/web dev`)
+- Add dependency to a workspace: `npm i <pkg> -w <name>`
+
+## Testing
+- UI: `npm test -w @vgmo/ui` (Storybook test runner + coverage)
+- Web: `npm test -w @vgmo/web`
+- Crawler: `npm test -w @vgmo/crawler` (Node 22+)
+
+## Documentation
+- Root documentation: keep `README.md`, `AGENTS.md`, and this guide up to date.
+- Each workspace manages its own `README.md` with setup and usage details under `services/*` and `packages/*`.
+
+## License
+By contributing, you agree that your contributions are licensed under the MIT License (see `LICENSE`).
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Repository Guidelines
+
+## Monorepo & npm Workspaces
+- This repository is a monorepo managed with npm workspaces.
+- Workspaces: `packages/*`, `services/*` (each package has its own `package.json`).
+- Install all: `npm ci` (run at the repo root).
+- Run in a specific workspace: use `-w <name>`, e.g. `npm run -w @vgmo/ui build`.
+- Run across all workspaces: `npm run build --workspaces` / `npm test --workspaces`.
+- Add a dependency to a specific workspace: `npm i <pkg> -w @vgmo/web`.
+- Use Node LTS and execute commands from the repository root.
+
+## Project Structure & Module Organization
+- Monorepo using npm workspaces: `packages/*` and `services/*`.
+- `packages/ui` — Preact UI library with Storybook. Source in `src`, build to `lib`, stories `*.stories.tsx`.
+- `services/web` — Astro site using the UI package. Code in `src`, tests in `tests`.
+- `services/crawler` — Node/TypeScript crawler. Code in `src`, tests in `tests`, build to `lib`.
+- Root config: `biome.json` (lint/format), `cspell.json` (spelling), `tsconfig.json`, `.pre-commit-config.yaml`.
+
+## Build, Test, and Development Commands
+- Install: `npm ci`
+- Build all workspaces: `npm run build`
+- Test all workspaces: `npm test`
+- UI Storybook (dev/build): `npm run storybook -w @vgmo/ui`, `npm run build-storybook -w @vgmo/ui`
+- UI tests + coverage: `npm test -w @vgmo/ui`
+- Web dev/build/preview: `npm run -w @vgmo/web dev|build|preview`
+- Crawler build/test/coverage: `npm run -w @vgmo/crawler build|test|coverage`
+
+Tip: Use `-w <workspace>` for a single package, and `--workspaces` to target all.
+
+## Coding Style & Naming Conventions
+- Language: TypeScript; JSX via Preact (`jsx: react-jsx`, `jsxImportSource: preact`).
+- Prefer TypeScript for all new code (`.ts`/`.tsx`) over JavaScript (`.js`/`.mjs`).
+- Use strict typing (no implicit `any`); justify exceptions in PRs.
+- When JS output is required, keep sources in TS and emit JS via the build.
+- Formatter/Linter: Biome. Run locally with `biome ci .` or via pre-commit.
+- Indentation: spaces; organize imports (enabled in `biome.json`).
+- Components: PascalCase directories and files (e.g., `src/Button/`, `Button.stories.tsx`).
+- Modules: prefer `ComponentName/index.tsx` entry files; keep `src/` for sources.
+
+## Dependency Policy
+- Do not add unnecessary libraries to any `package.json`.
+- Prefer the Node.js/ECMAScript standard library first; try built‑ins before adding deps.
+- If a dependency is truly needed, prefer packages already used in the repo (reuse existing deps in the workspace or another workspace) before introducing a new one.
+- Evaluate new deps for maintenance, security, license, size/tree‑shaking, and TypeScript support.
+- Scope dependencies to the specific workspace that needs them; only add to the root for shared tooling.
+- In PRs that add a new dependency, include a brief justification and alternatives considered.
+
+## Testing Guidelines
+- UI: Storybook Test Runner (`npm test -w @vgmo/ui`) with coverage output (nyc + Storybook JSON).
+- Web: Node test runner (`node --test`) via `npm test -w @vgmo/web`.
+- Crawler: Node test runner with `--experimental-strip-types` via `npm test -w @vgmo/crawler`; coverage with `npm run -w @vgmo/crawler coverage` (c8).
+- Test files: `*.test.ts`. Keep unit tests near `tests/` directories.
+
+## Commit & Pull Request Guidelines
+- Commits: follow Conventional Commits (e.g., `feat(ui): add Button`, `fix(crawler): ...`, `chore(spell): ...`).
+- PRs: include a clear summary, link related issues, and add screenshots for UI changes. Reference Storybook/Chromatic when relevant.
+- CI: ensure Node CI passes (build + tests), Biome linting passes, and Chromatic checks (for UI) are green.
+
+## Security & Tooling Tips
+- Enable pre-commit hooks: `pre-commit install` (runs Biome, cspell, hadolint, secretlint).
+- Do not commit secrets; secretlint will flag them. Stick to Node LTS (`lts/*`).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,81 @@
-# Title
+# vgmo
 
-## Install
+Monorepo managed with npm workspaces containing:
+- `packages/ui`: Preact UI component library with Storybook and tests
+- `services/web`: Astro website using the UI package
+- `services/crawler`: Node/TypeScript crawler service
 
-    npm install
+## Table of Contents
+- Requirements
+- Installation
+- Quick Start
+- Development
+- Workspaces
+- Testing
+- Linting & Formatting
+- Project Structure
+- Contributing
+- Security
+- License
 
-## Usage
+## Requirements
+- Node.js 20+ recommended
+  - For `services/crawler` tests using `--experimental-strip-types`, Node.js 22+ is required
+- npm (bundled with Node)
+- Git
+- Optional: Docker (for the `secretlint` pre-commit hook)
 
-> TBD
+## Installation
+Run all commands from the repository root.
+
+```sh
+npm ci
+```
+
+Install pre-commit hooks (recommended):
+
+```sh
+pre-commit install
+```
+
+## Quick Start
+- Build all workspaces: `npm run build`
+- Run the website (Astro) in dev: `npm run -w @vgmo/web dev`
+- Open Storybook for UI: `npm run -w @vgmo/ui storybook`
+
+## Development
+- Use Node LTS (20+) and run commands at the repo root
+- Add dependencies to a specific workspace with `-w`, e.g. `npm i <pkg> -w @vgmo/web`
+- Keep changes scoped to a single workspace when possible
+
+## Workspaces
+- This repository is a monorepo managed by npm workspaces
+- Workspaces: `packages/*`, `services/*`
+- Run in a specific workspace: `npm run -w <name> <script>` (e.g., `npm run -w @vgmo/ui build`)
+- Run across all workspaces: `npm run <script> --workspaces` (e.g., `npm run build --workspaces`)
+
+## Testing
+- Run all tests: `npm test`
+- UI package: `npm test -w @vgmo/ui` (Storybook test runner + coverage)
+- Web service: `npm test -w @vgmo/web` (Node test runner)
+- Crawler service: `npm test -w @vgmo/crawler` (Node test runner; Node 22+ for `--experimental-strip-types`)
+
+## Linting & Formatting
+- Biome is used for linting/formatting. Run: `biome ci .`
+- Spelling checks via `cspell`: `npx cspell .`
+- Pre-commit hooks run Biome, cspell, hadolint, and secretlint
+
+## Project Structure
+- `packages/ui/` — Preact components, stories in `src/**/Component.stories.tsx`, build to `lib/`
+- `services/web/` — Astro app, pages/layouts/components under `src/`, tests in `tests/`
+- `services/crawler/` — Node/TypeScript crawler, source in `src/`, tests in `tests/`, build to `lib/`
+- Config: `biome.json`, `cspell.json`, `tsconfig.json`, `.pre-commit-config.yaml`
 
 ## Contributing
+See `.github/CONTRIBUTING.md` for guidelines (branching, code style, testing, and PR checklist).
 
-PRs accepted.
+## Security
+See `SECURITY.md` for the security policy and reporting.
 
 ## License
-
-[MIT](./LICENSE) © TBA
+MIT — see `LICENSE`.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,17 +1,30 @@
-# @app/ui
+# @vgmo/ui
 
-## Install
+Preact UI component library used by the vgmo monorepo, with Storybook and Storybook Test Runner for coverage.
 
-> TBA
+## Requirements
+- Node.js 20+
+- npm
 
-## Usage
+## Setup
+Install dependencies at the repository root:
 
-> TBA
+```sh
+npm ci
+```
+
+## Scripts
+- Build: `npm run -w @vgmo/ui build` (TypeScript build to `lib/`)
+- Storybook (dev): `npm run -w @vgmo/ui storybook`
+- Storybook (build): `npm run -w @vgmo/ui build-storybook`
+- Test + coverage: `npm test -w @vgmo/ui`
+
+## Development Notes
+- Components are organized as `src/ComponentName/` with `index.tsx` and `ComponentName.stories.tsx`
+- Styling via Twind (`twind.config.ts`)
 
 ## Contributing
-
-PRs accepted.
+Please read the repository contributing guide at `../../.github/CONTRIBUTING.md` and follow Conventional Commits.
 
 ## License
-
-MIT © TBA
+MIT — see repository `LICENSE`.

--- a/services/crawler/README.md
+++ b/services/crawler/README.md
@@ -1,0 +1,25 @@
+# @vgmo/crawler
+
+Node/TypeScript crawler service.
+
+## Requirements
+- Node.js 22+ (required for `--experimental-strip-types` in tests)
+- npm
+
+## Setup
+Install dependencies at the repository root:
+
+```sh
+npm ci
+```
+
+## Scripts
+- Build: `npm run -w @vgmo/crawler build` (emits to `lib/`)
+- Tests: `npm test -w @vgmo/crawler`
+- Coverage: `npm run -w @vgmo/crawler coverage`
+
+## Contributing
+Please read the repository contributing guide at `../../.github/CONTRIBUTING.md`.
+
+## License
+MIT — see repository `LICENSE`.

--- a/services/web/README.md
+++ b/services/web/README.md
@@ -1,0 +1,31 @@
+# @vgmo/web
+
+Astro website that consumes the `@vgmo/ui` component library.
+
+## Requirements
+- Node.js 20+
+- npm
+
+## Setup
+Install dependencies at the repository root:
+
+```sh
+npm ci
+```
+
+## Scripts
+- Dev server: `npm run -w @vgmo/web dev`
+- Build: `npm run -w @vgmo/web build`
+- Preview: `npm run -w @vgmo/web preview`
+- Type check: `npm run -w @vgmo/web check`
+- Tests: `npm test -w @vgmo/web`
+
+## Notes
+- Uses Astro 5 and Preact integration
+- UI components are imported from `@vgmo/ui`
+
+## Contributing
+Please read the repository contributing guide at `../../.github/CONTRIBUTING.md`.
+
+## License
+MIT — see repository `LICENSE`.


### PR DESCRIPTION
This PR updates repository documentation:

- Add Standard Readme at the root with environment setup and workspace guidance
- Add per-workspace READMEs for services and packages with setup instructions
- Move contributing guide to .github/CONTRIBUTING.md and update references
- Update AGENTS.md with npm workspaces usage, dependency policy, and TypeScript preference

Notes:
- Crawler tests require Node 22+ due to --experimental-strip-types
- Pre-commit hooks (Biome, cspell, hadolint, secretlint) are supported

Closes: N/A