### PR TITLE
feat(ui): test-storybook実行時にカバレッジレポートを記録する

### DIFF
--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -11,7 +11,14 @@ const config: StorybookConfig = {
 
   addons: [
     getAbsolutePath("@storybook/addon-links"),
-    getAbsolutePath("@storybook/addon-coverage"),
+    {
+      name: getAbsolutePath("@storybook/addon-coverage"),
+      options: {
+        istanbul: {
+          include: ["src/**/*"],
+        },
+      },
+    },
     getAbsolutePath("@storybook/addon-docs"),
   ],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc --build .",
-    "test": "test-storybook",
+    "test": "test-storybook --coverage",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
`test-storybook` の実行時にカバレッジレポートが生成されるように、`packages/ui/package.json` の `test` スクリプトに `--coverage` フラグを追加しました。

また、`@storybook/addon-coverage` がすべてのコンポーネントを正しく計装できるように、`packages/ui/.storybook/main.ts` の設定を修正しました。これにより、以前は計装されていなかった `Breadcrumbs` と `Card` コンポーネントのカバレッジが正しくレポートされるようになりました。

なお、`Header` コンポーネントのテストは、この変更以前から失敗しており、今回の修正の範囲外です。