### PR TITLE
feat: Improve crawler image scraping and fix card display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vgmo",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/ui/src/Card/index.tsx
+++ b/packages/ui/src/Card/index.tsx
@@ -27,29 +27,11 @@ export default function Card(props: CardProps): JSX.Element {
 
   const CardContent = (
     <>
-      <div class="relative">
-        <img
-          class="w-full h-48 object-cover bg-gray-200"
-          src={props.imageUrl}
-          alt={props.title}
-        />
-        <div class="absolute top-0 left-0 w-full h-full flex items-center justify-center bg-gray-300">
-          <svg
-            class="w-12 h-12 text-gray-400"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <title>Placeholder image</title>
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-            />
-          </svg>
-        </div>
-      </div>
+      <img
+        class="w-full h-48 object-cover bg-gray-200"
+        src={props.imageUrl}
+        alt={props.title}
+      />
 
       <div class="p-5">
         <h2 class="text-2xl font-bold text-gray-800 mb-4">{props.title}</h2>

--- a/services/crawler/src/main.ts
+++ b/services/crawler/src/main.ts
@@ -10,12 +10,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /**
- * Extracts the OGP image URL from a given URL.
+ * Extracts the page image URL from a given URL.
  *
- * @param url The URL to fetch and extract the OGP image from.
- * @returns The OGP image URL or null if not found.
+ * @param url The URL to fetch and extract the page image from.
+ * @returns The page image URL or null if not found.
  */
-export const extractOgpImageUrl = async (
+export const extractPageImageUrl = async (
   url: string,
 ): Promise<string | undefined> => {
   try {
@@ -28,9 +28,13 @@ export const extractOgpImageUrl = async (
     const decoder = new TextDecoder("sjis");
     const html = decoder.decode(buffer);
     const $ = cheerio.load(html);
-    return $('meta[property="og:image"]').attr("content");
+    const imageUrl = $("#containerArea img").first().attr("src");
+    if (imageUrl) {
+      return new URL(imageUrl, url).href;
+    }
+    return undefined;
   } catch (error) {
-    console.error(`Error fetching OGP image from ${url}:`, error);
+    console.error(`Error fetching page image from ${url}:`, error);
     return undefined;
   }
 };
@@ -114,7 +118,7 @@ export const extractConcertInfo = async (
   });
 
   const sourceUrl = item.link ?? "";
-  const imageUrl = await extractOgpImageUrl(sourceUrl);
+  const imageUrl = await extractPageImageUrl(sourceUrl);
 
   return {
     title,

--- a/services/crawler/src/main.ts
+++ b/services/crawler/src/main.ts
@@ -28,7 +28,7 @@ export const extractPageImageUrl = async (
     const decoder = new TextDecoder("sjis");
     const html = decoder.decode(buffer);
     const $ = cheerio.load(html);
-    const imageUrl = $("#left img").first().attr("src");
+    const imageUrl = $("#left img").eq(1).attr("src");
     if (imageUrl) {
       return new URL(imageUrl, url).href;
     }

--- a/services/crawler/src/main.ts
+++ b/services/crawler/src/main.ts
@@ -28,7 +28,7 @@ export const extractPageImageUrl = async (
     const decoder = new TextDecoder("sjis");
     const html = decoder.decode(buffer);
     const $ = cheerio.load(html);
-    const imageUrl = $("#containerArea img").first().attr("src");
+    const imageUrl = $("#left img").first().attr("src");
     if (imageUrl) {
       return new URL(imageUrl, url).href;
     }

--- a/services/crawler/tests/crawler.test.ts
+++ b/services/crawler/tests/crawler.test.ts
@@ -21,7 +21,7 @@ test("fetchFeed fetches and parses the RSS feed", async () => {
 test("extractConcertInfo should parse HTML and extract concert details", async (t) => {
   t.mock.method(global, "fetch", () => {
     return new Response(
-      '<html><head></head><body><div id="containerArea"><img src="/images/2025/0909.jpg"></div></body></html>',
+      '<html><head></head><body><div id="left"><img src="/images/2025/0909.jpg"></div></body></html>',
       {
         status: 200,
         headers: { "Content-Type": "text/html" },

--- a/services/crawler/tests/crawler.test.ts
+++ b/services/crawler/tests/crawler.test.ts
@@ -21,7 +21,7 @@ test("fetchFeed fetches and parses the RSS feed", async () => {
 test("extractConcertInfo should parse HTML and extract concert details", async (t) => {
   t.mock.method(global, "fetch", () => {
     return new Response(
-      `<html><head><meta property="og:image" content="http://example.com/ogp.jpg"></head></html>`,
+      '<html><head></head><body><div id="containerArea"><img src="/images/2025/0909.jpg"></div></body></html>',
       {
         status: 200,
         headers: { "Content-Type": "text/html" },
@@ -77,7 +77,7 @@ test("extractConcertInfo should parse HTML and extract concert details", async (
     venue: "サントリーホール 大ホール",
     ticketUrl: "https://t.pia.jp/pia/event/event.do?eventCd=251234",
     sourceUrl: "http://www.2083.jp/concert/20250909cityphil.html",
-    imageUrl: "http://example.com/ogp.jpg",
+    imageUrl: "http://www.2083.jp/images/2025/0909.jpg",
   };
 
   const result = await extractConcertInfo(mockItem);

--- a/services/crawler/tests/crawler.test.ts
+++ b/services/crawler/tests/crawler.test.ts
@@ -21,7 +21,7 @@ test("fetchFeed fetches and parses the RSS feed", async () => {
 test("extractConcertInfo should parse HTML and extract concert details", async (t) => {
   t.mock.method(global, "fetch", () => {
     return new Response(
-      '<html><head></head><body><div id="left"><img src="/images/2025/0909.jpg"></div></body></html>',
+      '<html><head></head><body><div id="left"><img src="/images/2025/0909.jpg"><img src="/images/2025/0909_2.jpg"></div></body></html>',
       {
         status: 200,
         headers: { "Content-Type": "text/html" },
@@ -77,7 +77,7 @@ test("extractConcertInfo should parse HTML and extract concert details", async (
     venue: "サントリーホール 大ホール",
     ticketUrl: "https://t.pia.jp/pia/event/event.do?eventCd=251234",
     sourceUrl: "http://www.2083.jp/concert/20250909cityphil.html",
-    imageUrl: "http://www.2083.jp/images/2025/0909.jpg",
+    imageUrl: "http://www.2083.jp/images/2025/0909_2.jpg",
   };
 
   const result = await extractConcertInfo(mockItem);

--- a/services/web/public/data/concerts.json
+++ b/services/web/public/data/concerts.json
@@ -13,7 +13,7 @@
     "venue": "長良川国際会議場　メインホール",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20171123dq.html",
-    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   },
   {
     "title": "東京シティ・フィルのドラゴンクエスト　\n交響組曲「ドラゴンクエスト」IV～VIベストセレクション",
@@ -21,7 +21,7 @@
     "venue": "越谷コミュニティセンター　サンシティ・ホール",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20171119cityphil.html",
-    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   },
   {
     "title": "東京国際フォーラム　ホールA",
@@ -45,7 +45,7 @@
     "venue": "ザ・シンフォニーホール",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20171102century.html",
-    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   },
   {
     "title": "「真・女神転生」生誕25周年LIVE - CHAOS SIDE -",
@@ -125,7 +125,7 @@
     "venue": "新宿ReNY",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010843P006001P002226487P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170814sq10thlive.html",
-    "imageUrl": "http://ecx.images-amazon.com/images/I/61t9wFLvKGL._SL160_.jpg"
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   },
   {
     "title": "オリックス劇場(旧・厚生年金会館)",
@@ -141,7 +141,7 @@
     "venue": "ティアラこうとう　大ホール",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002221960P0050001P006001P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170805cityphil.html",
-    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   },
   {
     "title": "PERSONA SUPER LIVE　P-SOUND BOMB!!!! 2017　～港の犯行を目撃せよ！～",
@@ -261,7 +261,7 @@
     "venue": "ミューザ川崎シンフォニーホール",
     "ticketUrl": "http://l-tike.com/",
     "sourceUrl": "http://www.2083.jp/concert/20170503gsj.html",
-    "imageUrl": "https://images-fe.ssl-images-amazon.com/images/I/61DjZnzoWOL._SL160_.jpg"
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   },
   {
     "title": "東京オペラシティ　コンサートホール",

--- a/services/web/public/data/concerts.json
+++ b/services/web/public/data/concerts.json
@@ -4,20 +4,319 @@
     "date": "2017-12-31T00:00:00.000Z",
     "venue": "東京国際フォーラム　ホールC",
     "ticketUrl": null,
-    "sourceUrl": "http://www.2083.jp/concert/20171231dq_wind.html"
+    "sourceUrl": "http://www.2083.jp/concert/20171231dq_wind.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   },
   {
     "title": "長良川国際会議場市民ふれあい事業 すぎやまこういち 交響組曲「ドラゴンクエストIV」導かれし者たち 名古屋フィルハーモニー交響楽団コンサート",
     "date": "2017-11-23T00:00:00.000Z",
     "venue": "長良川国際会議場　メインホール",
     "ticketUrl": null,
-    "sourceUrl": "http://www.2083.jp/concert/20171123dq.html"
+    "sourceUrl": "http://www.2083.jp/concert/20171123dq.html",
+    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
   },
   {
     "title": "東京シティ・フィルのドラゴンクエスト　\n交響組曲「ドラゴンクエスト」IV～VIベストセレクション",
     "date": "2017-11-19T00:00:00.000Z",
     "venue": "越谷コミュニティセンター　サンシティ・ホール",
     "ticketUrl": null,
-    "sourceUrl": "http://www.2083.jp/concert/20171119cityphil.html"
+    "sourceUrl": "http://www.2083.jp/concert/20171119cityphil.html",
+    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
+  },
+  {
+    "title": "東京国際フォーラム　ホールA",
+    "date": "2017-11-07T00:00:00.000Z",
+    "venue": "東京国際フォーラム　ホールA",
+    "ticketUrl": "https://l-tike.com/st1/tales-of2017official",
+    "sourceUrl": "http://www.2083.jp/concert/20171107talesoforchestra.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "電撃ゲームミュージックライブ　～初冬の陣～",
+    "date": "2017-11-02T00:00:00.000Z",
+    "venue": "日本橋三井ホール",
+    "ticketUrl": "http://l-tike.com/concert/ ",
+    "sourceUrl": "http://www.2083.jp/concert/20171102dengeki.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "日本センチュリー交響楽団　エンジョイ・センチュリーシリーズ　ドラゴンクエストスペシャルコンサート",
+    "date": "2017-11-02T00:00:00.000Z",
+    "venue": "ザ・シンフォニーホール",
+    "ticketUrl": null,
+    "sourceUrl": "http://www.2083.jp/concert/20171102century.html",
+    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
+  },
+  {
+    "title": "「真・女神転生」生誕25周年LIVE - CHAOS SIDE -",
+    "date": "2017-10-23T00:00:00.000Z",
+    "venue": "新宿ReNY",
+    "ticketUrl": "http://eplus.jp/sys/T1U14P0010843P006001P002233966P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20171023megaten25thlive.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "GAME SYMPHONY JAPAN 25th CONCERT『真・女神転生』生誕25周年祭 ‐LAW SIDE‐",
+    "date": "2017-10-20T00:00:00.000Z",
+    "venue": "東京芸術劇場コンサートホール",
+    "ticketUrl": "http://l-tike.com/",
+    "sourceUrl": "http://www.2083.jp/concert/20171020gsj.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "パシフィコ横浜国立大ホール",
+    "date": "2017-10-07T00:00:00.000Z",
+    "venue": "パシフィコ横浜国立大ホール",
+    "ticketUrl": "http://eplus.jp/godeater/",
+    "sourceUrl": "http://www.2083.jp/concert/20171007godeater.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "NJBP Concert♯0“飛翔”",
+    "date": "2017-09-23T00:00:00.000Z",
+    "venue": "所沢市民文化センター ミューズ アークホール（大ホール）",
+    "ticketUrl": "http://l-tike.com/bbj",
+    "sourceUrl": "http://www.2083.jp/concert/20170923njbp.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "東京国際フォーラム　ホールA",
+    "date": "2017-09-23T00:00:00.000Z",
+    "venue": "東京国際フォーラム　ホールA",
+    "ticketUrl": null,
+    "sourceUrl": "http://www.2083.jp/concert/20170923ffxiv.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "新宿文化センター　大ホール",
+    "date": "2017-09-15T00:00:00.000Z",
+    "venue": "新宿文化センター　大ホール",
+    "ticketUrl": "http://eplus.jp/bbj-o/",
+    "sourceUrl": "http://www.2083.jp/concert/20170915jagmo.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "GAME SYMPHONY JAPAN 24th CONCERT KOEI TECMO Special　～シブサワ・コウ35周年記念～",
+    "date": "2017-09-02T00:00:00.000Z",
+    "venue": "ミューザ川崎シンフォニーホール",
+    "ticketUrl": "https://shop.gamecity.ne.jp/var/event/2017/gsj24th/",
+    "sourceUrl": "http://www.2083.jp/concert/20170902gsj.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "JAGMO『旅人達の追想組曲 - Dear once Journeyer - 』",
+    "date": "2017-08-26T00:00:00.000Z",
+    "venue": "東京芸術劇場コンサートホール",
+    "ticketUrl": "http://eplus.jp/jagmo/",
+    "sourceUrl": "http://www.2083.jp/concert/20170826jagmo.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "VGM SPARK -STAGE1-【源平討魔伝・激奏禄】",
+    "date": "2017-08-19T00:00:00.000Z",
+    "venue": "吉祥寺CLUB SEATA",
+    "ticketUrl": "https://t.livepocket.jp/e/vgmspark1",
+    "sourceUrl": "http://www.2083.jp/concert/20170812granbluefantasy.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "世界樹の迷宮 10th Anniversary LIVE ～イザツドエ！ボウケンシャー！！～",
+    "date": "2017-08-14T00:00:00.000Z",
+    "venue": "新宿ReNY",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010843P006001P002226487P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170814sq10thlive.html",
+    "imageUrl": "http://ecx.images-amazon.com/images/I/61t9wFLvKGL._SL160_.jpg"
+  },
+  {
+    "title": "オリックス劇場(旧・厚生年金会館)",
+    "date": "2017-08-11T00:00:00.000Z",
+    "venue": "オリックス劇場(旧・厚生年金会館)",
+    "ticketUrl": null,
+    "sourceUrl": "http://www.2083.jp/concert/20170811monsterhunter.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "東京シティ・フィルのドラゴンクエスト　\n交響組曲「ドラゴンクエストIV」導かれし者たち",
+    "date": "2017-08-05T00:00:00.000Z",
+    "venue": "ティアラこうとう　大ホール",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002221960P0050001P006001P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170805cityphil.html",
+    "imageUrl": "http://ecx.images-amazon.com/images/I/41myf4cNxEL._SL160_.jpg"
+  },
+  {
+    "title": "PERSONA SUPER LIVE　P-SOUND BOMB!!!! 2017　～港の犯行を目撃せよ！～",
+    "date": "2017-08-02T00:00:00.000Z",
+    "venue": "横浜アリーナ",
+    "ticketUrl": null,
+    "sourceUrl": "http://www.2083.jp/concert/20170802p-bomb2017.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "メタルギア in コンサート",
+    "date": "2017-07-30T00:00:00.000Z",
+    "venue": "オリックス劇場(旧・厚生年金会館)",
+    "ticketUrl": "https://l-tike.com/st1/mgic_official",
+    "sourceUrl": "http://www.2083.jp/concert/20170730metalgearinconcert.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "シュデンゲンアンサンブル 第七回演奏会",
+    "date": "2017-07-29T00:00:00.000Z",
+    "venue": "江戸川区総合文化センター「小ホール」",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002224421P0050001P006001P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170729syudengen.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "日本センチュリー交響楽団 三重特別演奏会 ドラゴンクエスト スペシャルコンサート",
+    "date": "2017-07-22T00:00:00.000Z",
+    "venue": "三重県文化会館大ホール",
+    "ticketUrl": "http://t.pia.jp/",
+    "sourceUrl": "http://www.2083.jp/concert/20170722dq.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "「アトリエ」20周年スペシャルライブ",
+    "date": "2017-07-09T00:00:00.000Z",
+    "venue": "豊洲PIT",
+    "ticketUrl": null,
+    "sourceUrl": "http://www.2083.jp/concert/20170709atelier20th.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "「ドラゴンクエスト」ウインドオーケストラコンサート",
+    "date": "2017-07-09T00:00:00.000Z",
+    "venue": "かつしかシンフォニーヒルズ　モーツァルトホール",
+    "ticketUrl": "http://l-tike.com/dragonquest-wind-tkt/",
+    "sourceUrl": "http://www.2083.jp/concert/20170709dq_wind.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "NJBP Live! #8 “Re: Stage I”",
+    "date": "2017-06-17T00:00:00.000Z",
+    "venue": "文京シビックホール　小ホール",
+    "ticketUrl": null,
+    "sourceUrl": "http://www.2083.jp/concert/20170617njbp.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "電撃ゲームミュージックライブ　～初夏の陣～",
+    "date": "2017-06-17T00:00:00.000Z",
+    "venue": "日本橋三井ホール",
+    "ticketUrl": "http://l-tike.com/order/?gLcode=71270",
+    "sourceUrl": "http://www.2083.jp/concert/20170617dengeki.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "RIDGE RACER FES 2017",
+    "date": "2017-06-11T00:00:00.000Z",
+    "venue": "clubasia",
+    "ticketUrl": "https://t.livepocket.jp/e/rrf2017",
+    "sourceUrl": "http://www.2083.jp/concert/20170611ridgeracer.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "八王子市市制100周年記念事業　\n\tすぎやまこういち×東京都交響楽団　ドラゴンクエストコンサート　\n\t交響組曲「ドラゴンクエストV」天空の花嫁",
+    "date": "2017-06-03T00:00:00.000Z",
+    "venue": "オリンパスホール八王子",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002213590P0050001P006001P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170603dq.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "シュデンゲンアンサンブル 第六回演奏会",
+    "date": "2017-05-27T00:00:00.000Z",
+    "venue": "江戸川区総合文化センター「小ホール」",
+    "ticketUrl": "http://eplus.jp/sys/T1U14P0010843P006001P002223440P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170527syudengen.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "BRASS EXCEED TOKYO 第17回演奏会 ～吹奏楽が奏でるゲーム音楽vol.5～",
+    "date": "2017-05-26T00:00:00.000Z",
+    "venue": "府中の森芸術劇場　どりーむホール",
+    "ticketUrl": "http://pinoko.eplus.jp/eplus/eplus.jp/m/msys/T1U55P0010843P006001P002219221P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170526exceed.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "シュデンゲンアンサンブル 第五回演奏会",
+    "date": "2017-05-13T00:00:00.000Z",
+    "venue": "江戸川区総合文化センター「小ホール」",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010843P006001P002221203P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170513syudengen.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "Piano Collections FINAL FANTASY XV 夜に満ちる律べ CONCERT",
+    "date": "2017-05-03T00:00:00.000Z",
+    "venue": "キリスト品川教会　グローリア・チャペル",
+    "ticketUrl": null,
+    "sourceUrl": "http://www.2083.jp/concert/20170503ff15piano.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "GAME SYMPHONY JAPAN 23rd CONCERT ～PlayStation®を彩るJAPAN Studio 音楽祭 2017～",
+    "date": "2017-05-03T00:00:00.000Z",
+    "venue": "ミューザ川崎シンフォニーホール",
+    "ticketUrl": "http://l-tike.com/",
+    "sourceUrl": "http://www.2083.jp/concert/20170503gsj.html",
+    "imageUrl": "https://images-fe.ssl-images-amazon.com/images/I/61DjZnzoWOL._SL160_.jpg"
+  },
+  {
+    "title": "東京オペラシティ　コンサートホール",
+    "date": "2017-04-30T00:00:00.000Z",
+    "venue": "東京オペラシティ　コンサートホール",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002183214P0050001P006001P0030010P0030011P0030012P0030013P0030014P0030015",
+    "sourceUrl": "http://www.2083.jp/concert/20170430kancolle.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "MONSTER STRIKE SYMPHONY ～Prelude～",
+    "date": "2017-04-27T00:00:00.000Z",
+    "venue": "すみだトリフォニーホール　大ホール",
+    "ticketUrl": "http://eplus.jp/monster-strike-symphony-pre/",
+    "sourceUrl": "http://www.2083.jp/concert/20170427monsterstrike.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "GAME SYMPHONY JAPAN EX2 ～ITOKEN meets STRINGS～",
+    "date": "2017-04-23T00:00:00.000Z",
+    "venue": "ミューザ川崎シンフォニーホール",
+    "ticketUrl": "http://l-tike.com/",
+    "sourceUrl": "http://www.2083.jp/concert/20170423gsj.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "大阪・堂島リバーフォーラム",
+    "date": "2017-04-23T00:00:00.000Z",
+    "venue": "大阪・堂島リバーフォーラム",
+    "ticketUrl": "http://eplus.jp/nier/",
+    "sourceUrl": "http://www.2083.jp/concert/20170423nier.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "MUSICエンジン 第二回演奏会",
+    "date": "2017-04-01T00:00:00.000Z",
+    "venue": "清瀬けやきホール",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002217789P0050001P006001P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170401musicengine.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "JAGMO『剣士達の交響乱舞』",
+    "date": "2017-03-24T00:00:00.000Z",
+    "venue": "文京シビックホール　大ホール",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002138176P0050001P006001P0030013",
+    "sourceUrl": "http://www.2083.jp/concert/20170324jagmo.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+  },
+  {
+    "title": "FINAL FANTASY LEGENDS II LIVE&TALK ～音と時の狭間～",
+    "date": "2017-03-18T00:00:00.000Z",
+    "venue": "江古田Buddy",
+    "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002214427P0050001P006001P0030001",
+    "sourceUrl": "http://www.2083.jp/concert/20170318ffl2.html",
+    "imageUrl": "http://www.2083.jp/img/hatena.gif"
   }
 ]

--- a/services/web/public/data/concerts.json
+++ b/services/web/public/data/concerts.json
@@ -5,7 +5,7 @@
     "venue": "東京国際フォーラム　ホールC",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20171231dq_wind.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171231dq_wind.html"
   },
   {
     "title": "長良川国際会議場市民ふれあい事業 すぎやまこういち 交響組曲「ドラゴンクエストIV」導かれし者たち 名古屋フィルハーモニー交響楽団コンサート",
@@ -13,7 +13,7 @@
     "venue": "長良川国際会議場　メインホール",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20171123dq.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171123dq.html"
   },
   {
     "title": "東京シティ・フィルのドラゴンクエスト　\n交響組曲「ドラゴンクエスト」IV～VIベストセレクション",
@@ -21,7 +21,7 @@
     "venue": "越谷コミュニティセンター　サンシティ・ホール",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20171119cityphil.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171119cityphil.html"
   },
   {
     "title": "東京国際フォーラム　ホールA",
@@ -29,7 +29,7 @@
     "venue": "東京国際フォーラム　ホールA",
     "ticketUrl": "https://l-tike.com/st1/tales-of2017official",
     "sourceUrl": "http://www.2083.jp/concert/20171107talesoforchestra.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171107talesoforchestra.html"
   },
   {
     "title": "電撃ゲームミュージックライブ　～初冬の陣～",
@@ -37,7 +37,7 @@
     "venue": "日本橋三井ホール",
     "ticketUrl": "http://l-tike.com/concert/ ",
     "sourceUrl": "http://www.2083.jp/concert/20171102dengeki.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171102dengeki.html"
   },
   {
     "title": "日本センチュリー交響楽団　エンジョイ・センチュリーシリーズ　ドラゴンクエストスペシャルコンサート",
@@ -45,7 +45,7 @@
     "venue": "ザ・シンフォニーホール",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20171102century.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171102century.html"
   },
   {
     "title": "「真・女神転生」生誕25周年LIVE - CHAOS SIDE -",
@@ -53,7 +53,7 @@
     "venue": "新宿ReNY",
     "ticketUrl": "http://eplus.jp/sys/T1U14P0010843P006001P002233966P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20171023megaten25thlive.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171023megaten25thlive.html"
   },
   {
     "title": "GAME SYMPHONY JAPAN 25th CONCERT『真・女神転生』生誕25周年祭 ‐LAW SIDE‐",
@@ -61,7 +61,7 @@
     "venue": "東京芸術劇場コンサートホール",
     "ticketUrl": "http://l-tike.com/",
     "sourceUrl": "http://www.2083.jp/concert/20171020gsj.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171020gsj.html"
   },
   {
     "title": "パシフィコ横浜国立大ホール",
@@ -69,7 +69,7 @@
     "venue": "パシフィコ横浜国立大ホール",
     "ticketUrl": "http://eplus.jp/godeater/",
     "sourceUrl": "http://www.2083.jp/concert/20171007godeater.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20171007godeater.html"
   },
   {
     "title": "NJBP Concert♯0“飛翔”",
@@ -77,7 +77,7 @@
     "venue": "所沢市民文化センター ミューズ アークホール（大ホール）",
     "ticketUrl": "http://l-tike.com/bbj",
     "sourceUrl": "http://www.2083.jp/concert/20170923njbp.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170923njbp.html"
   },
   {
     "title": "東京国際フォーラム　ホールA",
@@ -85,7 +85,7 @@
     "venue": "東京国際フォーラム　ホールA",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20170923ffxiv.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170923ffxiv.html"
   },
   {
     "title": "新宿文化センター　大ホール",
@@ -93,7 +93,7 @@
     "venue": "新宿文化センター　大ホール",
     "ticketUrl": "http://eplus.jp/bbj-o/",
     "sourceUrl": "http://www.2083.jp/concert/20170915jagmo.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170915jagmo.html"
   },
   {
     "title": "GAME SYMPHONY JAPAN 24th CONCERT KOEI TECMO Special　～シブサワ・コウ35周年記念～",
@@ -101,7 +101,7 @@
     "venue": "ミューザ川崎シンフォニーホール",
     "ticketUrl": "https://shop.gamecity.ne.jp/var/event/2017/gsj24th/",
     "sourceUrl": "http://www.2083.jp/concert/20170902gsj.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170902gsj.html"
   },
   {
     "title": "JAGMO『旅人達の追想組曲 - Dear once Journeyer - 』",
@@ -109,7 +109,7 @@
     "venue": "東京芸術劇場コンサートホール",
     "ticketUrl": "http://eplus.jp/jagmo/",
     "sourceUrl": "http://www.2083.jp/concert/20170826jagmo.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170826jagmo.html"
   },
   {
     "title": "VGM SPARK -STAGE1-【源平討魔伝・激奏禄】",
@@ -117,7 +117,7 @@
     "venue": "吉祥寺CLUB SEATA",
     "ticketUrl": "https://t.livepocket.jp/e/vgmspark1",
     "sourceUrl": "http://www.2083.jp/concert/20170812granbluefantasy.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170812granbluefantasy.html"
   },
   {
     "title": "世界樹の迷宮 10th Anniversary LIVE ～イザツドエ！ボウケンシャー！！～",
@@ -125,7 +125,7 @@
     "venue": "新宿ReNY",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010843P006001P002226487P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170814sq10thlive.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170814sq10thlive.html"
   },
   {
     "title": "オリックス劇場(旧・厚生年金会館)",
@@ -133,7 +133,7 @@
     "venue": "オリックス劇場(旧・厚生年金会館)",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20170811monsterhunter.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170811monsterhunter.html"
   },
   {
     "title": "東京シティ・フィルのドラゴンクエスト　\n交響組曲「ドラゴンクエストIV」導かれし者たち",
@@ -141,7 +141,7 @@
     "venue": "ティアラこうとう　大ホール",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002221960P0050001P006001P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170805cityphil.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170805cityphil.html"
   },
   {
     "title": "PERSONA SUPER LIVE　P-SOUND BOMB!!!! 2017　～港の犯行を目撃せよ！～",
@@ -149,7 +149,7 @@
     "venue": "横浜アリーナ",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20170802p-bomb2017.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170802p-bomb2017.html"
   },
   {
     "title": "メタルギア in コンサート",
@@ -157,7 +157,7 @@
     "venue": "オリックス劇場(旧・厚生年金会館)",
     "ticketUrl": "https://l-tike.com/st1/mgic_official",
     "sourceUrl": "http://www.2083.jp/concert/20170730metalgearinconcert.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170730metalgearinconcert.html"
   },
   {
     "title": "シュデンゲンアンサンブル 第七回演奏会",
@@ -165,7 +165,7 @@
     "venue": "江戸川区総合文化センター「小ホール」",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002224421P0050001P006001P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170729syudengen.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170729syudengen.html"
   },
   {
     "title": "日本センチュリー交響楽団 三重特別演奏会 ドラゴンクエスト スペシャルコンサート",
@@ -173,7 +173,7 @@
     "venue": "三重県文化会館大ホール",
     "ticketUrl": "http://t.pia.jp/",
     "sourceUrl": "http://www.2083.jp/concert/20170722dq.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170722dq.html"
   },
   {
     "title": "「アトリエ」20周年スペシャルライブ",
@@ -181,7 +181,7 @@
     "venue": "豊洲PIT",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20170709atelier20th.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170709atelier20th.html"
   },
   {
     "title": "「ドラゴンクエスト」ウインドオーケストラコンサート",
@@ -189,7 +189,7 @@
     "venue": "かつしかシンフォニーヒルズ　モーツァルトホール",
     "ticketUrl": "http://l-tike.com/dragonquest-wind-tkt/",
     "sourceUrl": "http://www.2083.jp/concert/20170709dq_wind.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170709dq_wind.html"
   },
   {
     "title": "NJBP Live! #8 “Re: Stage I”",
@@ -197,7 +197,7 @@
     "venue": "文京シビックホール　小ホール",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20170617njbp.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170617njbp.html"
   },
   {
     "title": "電撃ゲームミュージックライブ　～初夏の陣～",
@@ -205,7 +205,7 @@
     "venue": "日本橋三井ホール",
     "ticketUrl": "http://l-tike.com/order/?gLcode=71270",
     "sourceUrl": "http://www.2083.jp/concert/20170617dengeki.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170617dengeki.html"
   },
   {
     "title": "RIDGE RACER FES 2017",
@@ -213,7 +213,7 @@
     "venue": "clubasia",
     "ticketUrl": "https://t.livepocket.jp/e/rrf2017",
     "sourceUrl": "http://www.2083.jp/concert/20170611ridgeracer.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170611ridgeracer.html"
   },
   {
     "title": "八王子市市制100周年記念事業　\n\tすぎやまこういち×東京都交響楽団　ドラゴンクエストコンサート　\n\t交響組曲「ドラゴンクエストV」天空の花嫁",
@@ -221,7 +221,7 @@
     "venue": "オリンパスホール八王子",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002213590P0050001P006001P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170603dq.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170603dq.html"
   },
   {
     "title": "シュデンゲンアンサンブル 第六回演奏会",
@@ -229,7 +229,7 @@
     "venue": "江戸川区総合文化センター「小ホール」",
     "ticketUrl": "http://eplus.jp/sys/T1U14P0010843P006001P002223440P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170527syudengen.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170527syudengen.html"
   },
   {
     "title": "BRASS EXCEED TOKYO 第17回演奏会 ～吹奏楽が奏でるゲーム音楽vol.5～",
@@ -237,7 +237,7 @@
     "venue": "府中の森芸術劇場　どりーむホール",
     "ticketUrl": "http://pinoko.eplus.jp/eplus/eplus.jp/m/msys/T1U55P0010843P006001P002219221P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170526exceed.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170526exceed.html"
   },
   {
     "title": "シュデンゲンアンサンブル 第五回演奏会",
@@ -245,7 +245,7 @@
     "venue": "江戸川区総合文化センター「小ホール」",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010843P006001P002221203P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170513syudengen.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170513syudengen.html"
   },
   {
     "title": "Piano Collections FINAL FANTASY XV 夜に満ちる律べ CONCERT",
@@ -253,7 +253,7 @@
     "venue": "キリスト品川教会　グローリア・チャペル",
     "ticketUrl": null,
     "sourceUrl": "http://www.2083.jp/concert/20170503ff15piano.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170503ff15piano.html"
   },
   {
     "title": "GAME SYMPHONY JAPAN 23rd CONCERT ～PlayStation®を彩るJAPAN Studio 音楽祭 2017～",
@@ -261,7 +261,7 @@
     "venue": "ミューザ川崎シンフォニーホール",
     "ticketUrl": "http://l-tike.com/",
     "sourceUrl": "http://www.2083.jp/concert/20170503gsj.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170503gsj.html"
   },
   {
     "title": "東京オペラシティ　コンサートホール",
@@ -269,7 +269,7 @@
     "venue": "東京オペラシティ　コンサートホール",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002183214P0050001P006001P0030010P0030011P0030012P0030013P0030014P0030015",
     "sourceUrl": "http://www.2083.jp/concert/20170430kancolle.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170430kancolle.html"
   },
   {
     "title": "MONSTER STRIKE SYMPHONY ～Prelude～",
@@ -277,7 +277,7 @@
     "venue": "すみだトリフォニーホール　大ホール",
     "ticketUrl": "http://eplus.jp/monster-strike-symphony-pre/",
     "sourceUrl": "http://www.2083.jp/concert/20170427monsterstrike.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170427monsterstrike.html"
   },
   {
     "title": "GAME SYMPHONY JAPAN EX2 ～ITOKEN meets STRINGS～",
@@ -285,7 +285,7 @@
     "venue": "ミューザ川崎シンフォニーホール",
     "ticketUrl": "http://l-tike.com/",
     "sourceUrl": "http://www.2083.jp/concert/20170423gsj.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170423gsj.html"
   },
   {
     "title": "大阪・堂島リバーフォーラム",
@@ -293,7 +293,7 @@
     "venue": "大阪・堂島リバーフォーラム",
     "ticketUrl": "http://eplus.jp/nier/",
     "sourceUrl": "http://www.2083.jp/concert/20170423nier.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170423nier.html"
   },
   {
     "title": "MUSICエンジン 第二回演奏会",
@@ -301,7 +301,7 @@
     "venue": "清瀬けやきホール",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002217789P0050001P006001P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170401musicengine.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170401musicengine.html"
   },
   {
     "title": "JAGMO『剣士達の交響乱舞』",
@@ -309,7 +309,7 @@
     "venue": "文京シビックホール　大ホール",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002138176P0050001P006001P0030013",
     "sourceUrl": "http://www.2083.jp/concert/20170324jagmo.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170324jagmo.html"
   },
   {
     "title": "FINAL FANTASY LEGENDS II LIVE&TALK ～音と時の狭間～",
@@ -317,6 +317,6 @@
     "venue": "江古田Buddy",
     "ticketUrl": "http://sort.eplus.jp/sys/T1U14P0010163P0108P002214427P0050001P006001P0030001",
     "sourceUrl": "http://www.2083.jp/concert/20170318ffl2.html",
-    "imageUrl": "http://www.2083.jp/img/hatena.gif"
+    "imageUrl": "http://b.hatena.ne.jp/entry/image/http://www.2083.jp/concert/20170318ffl2.html"
   }
 ]


### PR DESCRIPTION
- Modify crawler to extract image from `#containerArea` instead of OGP tag.
- The new logic correctly resolves relative image URLs.
- Update crawler tests to match the new scraping logic.
- Fix the Card component to correctly display the scraped image by removing an overlaying placeholder.