### PR TITLE
feat(web): remove unwanted elements and add footer

### DIFF
--- a/packages/ui/src/Header/index.tsx
+++ b/packages/ui/src/Header/index.tsx
@@ -5,7 +5,7 @@ type Props = {
 };
 
 export default function Header({ active }: Props) {
-  const menus = [{ name: "Home", href: "/" }];
+  const menus: { name: string; href: string }[] = [];
   const toggleId = "header-menu-toggle";
 
   return (

--- a/services/web/src/layouts/MainLayout.astro
+++ b/services/web/src/layouts/MainLayout.astro
@@ -1,4 +1,5 @@
 ---
+import Footer from "@vgmo/ui/src/Footer";
 import Header from "@vgmo/ui/src/Header";
 import TwindSetup from "../components/TwindSetup.astro";
 import {
@@ -44,5 +45,6 @@ const gaId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
         <slot />
       </main>
     </div>
+    <Footer />
   </body>
 </html>

--- a/services/web/src/pages/concert/[slug].astro
+++ b/services/web/src/pages/concert/[slug].astro
@@ -1,6 +1,5 @@
 ---
 import MainLayout from "../../layouts/MainLayout.astro";
-import { Breadcrumbs } from "@vgmo/ui/src/Breadcrumbs";
 import Card from "@vgmo/ui/src/Card";
 import type { CardProps } from "@vgmo/ui/src/Card";
 import type { ConcertWithMeta } from "../../utils/concerts";
@@ -40,13 +39,6 @@ const description = `${concert.date} @ ${concert.venue}`;
   </Fragment>
 
   <div class="space-y-4">
-    <Breadcrumbs
-      breadcrumbs={[
-        { label: "Home", href: "/" },
-        { label: "演奏情報", href: "/" },
-        { label: concert.title },
-      ]}
-    />
     <Card {...toCard(concert)} />
     <div class="mt-2 text-sm text-gray-700">
       <p>


### PR DESCRIPTION
- Remove the 'Home' link from the header.
- Remove the breadcrumbs from the concert page.
- Add a footer component to the main layout.