### PR TITLE
feat(web): remove unused hamburger and breadcrumbs menus

### DIFF
--- a/packages/ui/src/Header/index.tsx
+++ b/packages/ui/src/Header/index.tsx
@@ -2,50 +2,64 @@ import { Menu, Music, X } from "lucide-preact";
 
 type Props = {
   active: string;
+  menus?: { name: string; href: string }[];
 };
 
-export default function Header({ active }: Props) {
-  const menus: { name: string; href: string }[] = [];
+export default function Header({ active, menus = [] }: Props) {
   const toggleId = "header-menu-toggle";
 
   return (
-    <header class="bg-white w-full py-4 px-6 md:px-8 flex flex-col md:flex-row gap-4 shadow-md sticky top-0 z-50">
-      <div class="flex items-center justify-between">
+    <header class="bg-white w-full py-4 px-6 md:px-8 flex flex-col md:flex-row gap-4 items-center shadow-md sticky top-0 z-50">
+      <div class="flex items-center justify-between w-full md:w-auto">
         <a href="/" class="flex items-center">
           <Music aria-hidden="true" />
           <div class="text-2xl ml-1 font-bold">vgmo</div>
         </a>
+        {menus.length > 0 && (
+          <>
+            <input id={toggleId} type="checkbox" class="hidden peer md:hidden" />
+            <label
+              for={toggleId}
+              class="md:hidden flex items-center justify-end text-gray-500 hover:text-gray-700 cursor-pointer"
+              aria-controls="header-navigation"
+              aria-expanded={undefined}
+            >
+              <span class="sr-only">メニュー</span>
+              <Menu
+                size={24}
+                class="inline peer-checked:hidden"
+                aria-hidden="true"
+              />
+              <X
+                size={24}
+                class="hidden peer-checked:inline"
+                aria-hidden="true"
+              />
+            </label>
+          </>
+        )}
       </div>
-      <input id={toggleId} type="checkbox" class="hidden peer md:hidden" />
-      <label
-        for={toggleId}
-        class="md:hidden flex items-center justify-end text-gray-500 hover:text-gray-700 cursor-pointer"
-        aria-controls="header-navigation"
-        aria-expanded={undefined}
-      >
-        <span class="sr-only">メニュー</span>
-        <Menu size={24} class="inline peer-checked:hidden" aria-hidden="true" />
-        <X size={24} class="hidden peer-checked:inline" aria-hidden="true" />
-      </label>
-      <nav
-        id="header-navigation"
-        class="hidden peer-checked:block md:flex items-center gap-6"
-      >
-        <ul class="flex flex-col md:flex-row items-center gap-6">
-          {menus.map((menu) => (
-            <li key={menu.name}>
-              <a
-                href={menu.href}
-                class={`text-gray-500 hover:text-gray-700 py-1 border-gray-500 ${
-                  active === menu.name ? "font-bold border-b-2" : ""
-                }`}
-              >
-                {menu.name}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
+      {menus.length > 0 && (
+        <nav
+          id="header-navigation"
+          class="hidden peer-checked:block md:flex items-center gap-6 w-full md:w-auto"
+        >
+          <ul class="flex flex-col md:flex-row items-center gap-6">
+            {menus.map((menu) => (
+              <li key={menu.name}>
+                <a
+                  href={menu.href}
+                  class={`text-gray-500 hover:text-gray-700 py-1 border-gray-500 ${
+                    active === menu.name ? "font-bold border-b-2" : ""
+                  }`}
+                >
+                  {menu.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
     </header>
   );
 }

--- a/services/web/src/pages/index.astro
+++ b/services/web/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import { Breadcrumbs } from "@vgmo/ui/src/Breadcrumbs";
 import Card from "@vgmo/ui/src/Card";
 import type { CardProps } from "@vgmo/ui/src/Card";
 import type { ConcertWithMeta } from "../utils/concerts";
@@ -24,15 +23,7 @@ const concerts = await listConcerts();
 ---
 
 <MainLayout title="vgmo | ゲーム音楽オーケストラまとめ">
-  <div class="space-y-4">
-    <Breadcrumbs
-      breadcrumbs={[
-        { label: "Home", href: "#" },
-        { label: "演奏情報" },
-      ]}
-    />
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {concerts.map((c) => <Card {...toCard(c)} />)}
-    </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    {concerts.map((c) => <Card {...toCard(c)} />)}
   </div>
 </MainLayout>


### PR DESCRIPTION
This commit removes the hamburger menu and breadcrumbs from the `web` service.

The `Breadcrumbs` component was removed from the `index.astro` page as it was not providing value.

The `Header` component in `@vgmo/ui` has been updated to conditionally render the hamburger menu. The menu icon and navigation bar will now only be displayed if the `menus` prop is provided and contains items. This allows the `web` service to use the `Header` without displaying a hamburger menu, as it passes no menus.