### PR TITLE
feat(ui): make footer full-width

### DIFF
--- a/packages/ui/src/Footer/index.tsx
+++ b/packages/ui/src/Footer/index.tsx
@@ -14,44 +14,49 @@ type Props = {
 
 export default function Footer({ menus }: Props) {
   return (
-    <div class="bg-white flex flex-col md:flex-row w-full max-w-screen-lg gap-8 md:gap-16 px-8 py-8 text-sm">
-      <div class="flex-1">
-        <div class="flex items-center gap-1">
-          <Citrus class="inline-block" aria-hidden="true" />
-          <div class="font-bold text-2xl">Sample</div>
-        </div>
-        <div class="text-gray-500">Full Stack Framework</div>
-      </div>
-
-      {menus.map((item) => (
-        <div class="mb-4" key={item.title}>
-          <div class="font-bold">{item.title}</div>
-          <ul class="mt-2">
-            {item.children.map((child) => (
-              <li class="mt-2" key={child.name}>
-                <a class="text-gray-500 hover:text-gray-700" href={child.href}>
-                  {child.name}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ))}
-
-      <div class="text-gray-500 space-y-2">
-        <div class="text-xs">
-          Copyright © {new Date().getFullYear()} 9renpoto
-          <br />
-          All right reserved.
+    <div class="bg-white py-8 text-sm">
+      <div class="flex flex-col md:flex-row w-full max-w-7xl mx-auto gap-8 md:gap-16 px-4 sm:px-6 lg:px-8">
+        <div class="flex-1">
+          <div class="flex items-center gap-1">
+            <Citrus class="inline-block" aria-hidden="true" />
+            <div class="font-bold text-2xl">Sample</div>
+          </div>
+          <div class="text-gray-500">Full Stack Framework</div>
         </div>
 
-        <a
-          href="https://github.com/9renpoto/.59-node"
-          class="inline-block hover:text-black"
-          aria-label="GitHub"
-        >
-          <Github />
-        </a>
+        {menus.map((item) => (
+          <div class="mb-4" key={item.title}>
+            <div class="font-bold">{item.title}</div>
+            <ul class="mt-2">
+              {item.children.map((child) => (
+                <li class="mt-2" key={child.name}>
+                  <a
+                    class="text-gray-500 hover:text-gray-700"
+                    href={child.href}
+                  >
+                    {child.name}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+
+        <div class="text-gray-500 space-y-2">
+          <div class="text-xs">
+            Copyright © {new Date().getFullYear()} 9renpoto
+            <br />
+            All right reserved.
+          </div>
+
+          <a
+            href="https://github.com/9renpoto/.59-node"
+            class="inline-block hover:text-black"
+            aria-label="GitHub"
+          >
+            <Github />
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/services/web/src/layouts/MainLayout.astro
+++ b/services/web/src/layouts/MainLayout.astro
@@ -52,14 +52,16 @@ const menus = [
     <slot name="head" />
     {gaId && <GoogleAnalytics id={gaId} />}
   </head>
-  <body class="bg-gray-100">
+  <body class="bg-gray-100 flex flex-col min-h-screen">
     {gaId && <GoogleAnalyticsNoscript id={gaId} />}
     <Header active="Home" />
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="flex-grow max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
       <main class="py-6">
         <slot />
       </main>
     </div>
-    <Footer menus={menus} />
+    <footer class="w-full">
+      <Footer menus={menus} />
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
The footer background now spans the entire width of the viewport, while the content remains centered and aligned with the main content area.

This was achieved by:
- Wrapping the Footer component in a `<footer>` tag in `MainLayout.astro`.
- Applying `w-full` to the `<footer>` element.
- Restructuring the Footer component to have an outer container for the background and an inner container for the content.
- Using flexbox on the `<body>` to ensure the footer sticks to the bottom of the page, even on pages with short content.