### PR TITLE
fix(ci): reduce Node CI cancellations

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     permissions:
       contents: read
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-22.04
 
     strategy:
@@ -35,7 +35,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - run: npx playwright install --with-deps
+      - run: npx playwright install --with-deps chromium
       - name: Build Storybook
         run: npm run build-storybook --quiet
       - name: Serve Storybook and run tests


### PR DESCRIPTION
## Summary
- increase Node CI build job timeout from 10 to 20 minutes
- install only Chromium in Playwright setup step to reduce install time

## Why
Recent main runs were being cancelled while Playwright browser installation was running. This change reduces setup time and gives the job enough headroom to complete.