### PR TITLE
fix(ci): stabilize Node CI Playwright setup

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
     timeout-minutes: 10
     runs-on: ubuntu-22.04
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.1-noble
 
     strategy:
       matrix:
@@ -35,7 +37,6 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-      - run: npx playwright install --with-deps
       - name: Build Storybook
         run: npm run build-storybook --quiet
       - name: Serve Storybook and run tests


### PR DESCRIPTION
closes #275 

Summary:\n- Run the Node CI build job in mcr.microsoft.com/playwright:v1.56.1-noble\n- Remove npx playwright install --with-deps from the workflow\n- Avoid runner-image-dependent hangs during Playwright browser setup\n\nWhy:\nRecent Node CI runs stall after Chromium download during Playwright install and then hit the job timeout. Pre-baking browser dependencies in the job container removes that runtime install bottleneck.