### PR TITLE
fix(web): include ui sources in tailwind scan

### DIFF
--- a/services/web/src/styles/tailwind.css
+++ b/services/web/src/styles/tailwind.css
@@ -1,2 +1,2 @@
 @import "tailwindcss";
-@source "@vgmo/ui/src";
+@source "../../../../packages/ui/src";


### PR DESCRIPTION
Summary:\n- Replace Tailwind source for UI components with a monorepo workspace path\n- Ensure services/web scans packages/ui/src classes during build\n- Restore missing UI utility classes in deployed CSS\n\nWhy:\nThe previous source entry using @vgmo/ui/src was not resolved reliably in web builds. As a result, classes used inside the shared UI package were omitted from generated CSS and card layout broke in production.