### PR TITLE
Update concerts and fix crawler date parsing

### DIFF
--- a/services/crawler/src/main.ts
+++ b/services/crawler/src/main.ts
@@ -118,10 +118,9 @@ const parseDate = (text: string): string | null => {
   }
 
   const [, year, month, day] = dateMatch;
+  // Use JST (UTC+9) for parsing the date
   return new Date(
-    parseInt(year, 10),
-    parseInt(month, 10) - 1,
-    parseInt(day, 10),
+    `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}T00:00:00+09:00`,
   ).toISOString();
 };
 

--- a/services/crawler/tests/crawler.test.ts
+++ b/services/crawler/tests/crawler.test.ts
@@ -142,7 +142,7 @@ test("scrapeConcertPage should parse HTML and extract concert details", async (t
 
   const concert1 = results.find((c) => c.title === "Concert One");
   assert.ok(concert1, "Concert One should be found");
-  assert.strictEqual(concert1.date, new Date(2025, 9, 12).toISOString());
+  assert.strictEqual(concert1.date, "2025-10-11T15:00:00.000Z");
   assert.strictEqual(
     concert1.sourceUrl,
     "https://www.2083.jp/concert/concert-1.html",
@@ -160,7 +160,7 @@ test("scrapeConcertPage should parse HTML and extract concert details", async (t
 
   const concert2 = results.find((c) => c.title === "Concert Two");
   assert.ok(concert2, "Concert Two should be found");
-  assert.strictEqual(concert2.date, new Date(2025, 10, 15).toISOString());
+  assert.strictEqual(concert2.date, "2025-11-14T15:00:00.000Z");
   assert.strictEqual(
     concert2.sourceUrl,
     "https://www.2083.jp/concert/concert-2.html",

--- a/services/web/public/data/concerts.json
+++ b/services/web/public/data/concerts.json
@@ -16,6 +16,14 @@
     "imageUrl": "https://www.2083.jp/concert/img/20260821pokemon_img.jpg"
   },
   {
+    "title": "ファミ箏 第5回演奏会",
+    "date": "2026-08-06T15:00:00.000Z",
+    "ticketUrl": "https://teket.jp/17754/66994",
+    "sourceUrl": "https://www.2083.jp/concert/20260807famikoto.html",
+    "prefectures": ["東京"],
+    "imageUrl": "https://www.2083.jp/concert/img/20260807famikoto_img.jpg"
+  },
+  {
     "title": "NJBP Live! #18 “セガ・ゴールデン80's”",
     "date": "2026-07-24T15:00:00.000Z",
     "ticketUrl": "https://njbp.org/concert/live18/",
@@ -32,12 +40,28 @@
     "imageUrl": "https://www.2083.jp/concert/img/20260718gamemusicjam_img.jpg"
   },
   {
+    "title": "アナザーエデン音楽の祭典2026 Verses from the Astral Archive",
+    "date": "2026-07-17T15:00:00.000Z",
+    "ticketUrl": "https://www.jvcmusic.co.jp/another-eden/concert2026/",
+    "sourceUrl": "https://www.2083.jp/concert/20260718anothereden.html",
+    "prefectures": ["東京"],
+    "imageUrl": "https://www.2083.jp/concert/img/20260718anothereden_img.jpg"
+  },
+  {
     "title": "KENJI ITO CONCERT -gentle echo meets \"聖剣伝説\"-",
     "date": "2026-07-11T15:00:00.000Z",
     "ticketUrl": "https://teket.jp/13576/69130",
     "sourceUrl": "https://www.2083.jp/concert/20260712itoken.html",
     "prefectures": ["東京"],
     "imageUrl": "https://www.2083.jp/concert/img/20260712itoken_img.jpg"
+  },
+  {
+    "title": "STEINS;GATE「因果旋律のシンフォニー」",
+    "date": "2026-07-04T15:00:00.000Z",
+    "ticketUrl": "https://steinsgate-orchestra2026.com/matsudo/",
+    "sourceUrl": "https://www.2083.jp/concert/20260531steinsgate.html",
+    "imageUrl": "https://www.2083.jp/concert/img/20260531steinsgate_img.jpg",
+    "prefectures": ["愛知"]
   },
   {
     "title": "ペルソナ5 スペシャル・ビッグバンド・コンサート2026",
@@ -54,6 +78,14 @@
     "sourceUrl": "https://www.2083.jp/concert/20260628sonic.html",
     "prefectures": ["東京"],
     "imageUrl": "https://www.2083.jp/concert/img/20260628sonic_img.jpg"
+  },
+  {
+    "title": "BRA★BRA FINAL FANTASY BRASS de BRAVO 2026\nwith Siena Wind Orchestra",
+    "date": "2026-06-26T15:00:00.000Z",
+    "ticketUrl": "https://www.jp.square-enix.com/music/sem/page/brabraff/tour/2026/",
+    "sourceUrl": "https://www.2083.jp/concert/20260405brabraff.html",
+    "imageUrl": "https://www.2083.jp/concert/img/20260405brabraff_img.jpg",
+    "prefectures": ["広島", "大阪", "東京"]
   },
   {
     "title": "メタファー：リファンタジオ オーケストラコンサート -ReSimfonio-",
@@ -80,28 +112,12 @@
     "imageUrl": "https://www.2083.jp/concert/img/20260605hollowknight_img.jpg"
   },
   {
-    "title": "STEINS;GATE「因果旋律のシンフォニー」",
-    "date": "2026-05-30T15:00:00.000Z",
-    "ticketUrl": "https://steinsgate-orchestra2026.com/matsudo/",
-    "sourceUrl": "https://www.2083.jp/concert/20260531steinsgate.html",
-    "imageUrl": "https://www.2083.jp/concert/img/20260531steinsgate_img.jpg",
-    "prefectures": ["千葉", "愛知"]
-  },
-  {
     "title": "龍が如く THE LIVE -IKIZAMA-",
     "date": "2026-05-15T15:00:00.000Z",
     "ticketUrl": "https://ryu-ga-gotoku-live.com/",
     "sourceUrl": "https://www.2083.jp/concert/20260516ryugagotoku.html",
     "prefectures": ["東京"],
     "imageUrl": "https://www.2083.jp/concert/img/20260516ryugagotoku_img.jpg"
-  },
-  {
-    "title": "BRA★BRA FINAL FANTASY BRASS de BRAVO 2026\nwith Siena Wind Orchestra",
-    "date": "2026-05-15T15:00:00.000Z",
-    "ticketUrl": "https://www.jp.square-enix.com/music/sem/page/brabraff/tour/2026/",
-    "sourceUrl": "https://www.2083.jp/concert/20260405brabraff.html",
-    "imageUrl": "https://www.2083.jp/concert/img/20260405brabraff_img.jpg",
-    "prefectures": ["宮城", "東京", "福岡", "広島", "大阪"]
   },
   {
     "title": "Music 4Gamer #9\n「アイカツ！シリーズ」オーケストラコンサート\n『オケカツ！』2026 -Anniversary Baton-",


### PR DESCRIPTION
Ran the crawler to update the concert data. In the process, I identified and fixed a timezone dependency in the date parsing logic of the crawler. It now explicitly uses JST (UTC+9) when parsing dates from the source website, ensuring consistent UTC ISO strings in `concerts.json` regardless of the execution environment's timezone. Unit tests have been updated accordingly.

---
*PR created automatically by Jules for task [4367545044706177384](https://jules.google.com/task/4367545044706177384) started by @9renpoto*